### PR TITLE
Update __init__.py

### DIFF
--- a/classification_models_3D/__init__.py
+++ b/classification_models_3D/__init__.py
@@ -1,4 +1,4 @@
-import keras_applications as ka
+from keras import applications as ka
 from .__version__ import __version__
 
 


### PR DESCRIPTION
Using keras 2.9.0, `import keras_applications as ka` gives the following error:-
_ModuleNotFoundError: No module named 'keras_applications'_

Instead using `from keras import applications as ka` works!