### PR TITLE
Lower requirements to use the library

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+torch>=2.1.0
+jax[cpu]>=0.4.20
+matplotlib
+scikit-image

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-keras==3.3.3
-tensorflow==2.16.2
-torch==2.3.0
+tensorflow>=2.16.1
+keras>=3.0.0


### PR DESCRIPTION
Hello,

I apologize for bothering you again.
I mistakenly set very recent requirements on library whereas they are not really necessary. These requirements were tested with the minimum required version.
I have a very similar branch and PR on segmentation_models_3D repository.

I hope not to find any other problem with my initial branches :( 